### PR TITLE
Fix bugs and prettify codes

### DIFF
--- a/large-orders.html
+++ b/large-orders.html
@@ -1,22 +1,43 @@
-<!DOCTYPE html><html><head> <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"><link rel="stylesheet" type="text/css" href="large-orders.css" media="screen" /></head><body>
-   <div class="mb" id="menu-bar">	
-         <a class="menu" href="index.html">  <p class="box"> Home  |</p> </a>	 <a class="menu" href="about-us.html"> <p class="box"> About Us  |</p> </a> 	
- <a class="menu" href="menu.html"> <p class="box"> Menu  |</p> </a> <a class="menu" href="large-orders.html"> <p class="box"> Student Lunch Delivery  |</p> </a>	<a class="menu" href="http://taimeiren.wordpress.com"> <p class="box"> Blog  |</p>	</a> <a class="menu" href="location.html">  <p class="box"> Location  |</p> </a>	
-  <a class="menu" href="contact.html"> <p class="box"> Contact Us   |</p>  </a> 
-      
-      <a class="icons" href="https://www.facebook.com/Taiwan-Little-Eats-1940760822802866/"><i class="fa fa-facebook" aria-hidden="true"></i> </a>   	<a class="icons" href="https://www.yelp.com/biz/taiwan-little-eats-madison" > <i class="fa fa-yelp" aria-hidden="true"></i> </a>    		<a class="icons" href="https://www.instagram.com/taiwanlittleeats"> <i class="fa fa-instagram" aria-hidden="true"></i> </a>	   		</div>	
+<!DOCTYPE html>
+<html>
 
-   
+<head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="large-orders.css" media="screen" />
+</head>
+
+<body>
+    <div class="mb" id="menu-bar">
+        <a class="menu" href="index.html">
+            <div class="box"> Home|</div>
+        </a>
+        <a class="menu" href="about-us.html">
+            <div class="box"> About Us |</div>
+        </a>
+        <a class="menu" href="menu.html">
+            <div class="box"> Menu |</div>
+        </a>
+        <a class="menu" href="large-orders.html">
+            <div class="box"> Student Lunch Delivery |</div>
+        </a>
+        <a class="menu" href="http://taimeiren.wordpress.com">
+            <div class="box"> Blog |</div>
+        </a>
+        <a class="menu" href="location.html">
+            <div class="box"> Location |</div>
+        </a>
+        <a class="menu" href="contact.html">
+            <div class="box"> Contact Us |</div>
+        </a>
+        <a class="icons" href="https://www.facebook.com/Taiwan-Little-Eats-1940760822802866/"><i class="fa fa-facebook" aria-hidden="true"></i> </a> <a class="icons" href="https://www.yelp.com/biz/taiwan-little-eats-madison"> <i class="fa fa-yelp" aria-hidden="true"></i> </a> <a class="icons" href="https://www.instagram.com/taiwanlittleeats"> <i class="fa fa-instagram" aria-hidden="true"></i> </a>
+    </div>
     <p id='message'> Thanks so much for your support! We'll be offering more lunch options at a central delivery point Fall 2018. </p>
-    
-    
+</body>
+
+</html>
 <!-- <iframe src="https://services.cognitoforms.com/f/wnfFZgRDt0yRrkjchGtUNg?id=2" style="position:relative;width:1px;min-width:100%;*width:100%;" frameborder="0" scrolling="yes" seamless="seamless" height="2763" width="100%"></iframe>
 <script src="https://services.cognitoforms.com/scripts/embed.js"></script> -->
-    
-    
-    
-    
-   <!-- <div class="form">
+<!-- <div class="form">
         <h1 class="heading"> Student Lunch Delivery </h1> 
         <p class="descrip"> Starting February 13, we will deliver Big Bites and drinks to a central campus location (Humanities parking lot, on Park St.) every weekday at 11:30. Cash only. </p>
         <p class="descrip"> The online system receives orders starting the day before delivery, from 3:00 PM, to the day of delivery at 10:30 AM.  </p>
@@ -141,8 +162,6 @@
     <!--<p class="descrip">
     <input type="submit" value="Submit">
        <a href="www.taiwanlittleeats.com> Submit </a> -->
-
- <!--   </p>
+<!--   </p>
  </div>
 </form> -->
-    


### PR DESCRIPTION
The nav bar at top for now is somehow extended as you adds "p{}" in large-orders.css. As a result, I change all those boxes in the menu bar from  `<p>`  to `<div>`. Also, I change the message from `<div>` to `<p>`, which will make more sense in this situation. I also add `</body>` `</html>` to add an end of this html file. All other changes are about prettify codes.

Before:
<img width="1440" alt="screen shot 2018-07-29 at 12 17 44 pm" src="https://user-images.githubusercontent.com/32176299/43368878-743f583e-9329-11e8-8e3f-8c47f4817b97.png">

After:
<img width="1440" alt="screen shot 2018-07-29 at 12 17 50 pm" src="https://user-images.githubusercontent.com/32176299/43368879-744bed7e-9329-11e8-981e-01a81b625993.png">

Don't worry about the fonts shown in the screenshot. I didn't download the font file in your depository, so it should work fine as you combine my editing.

BTW, really love your guys' foods!!! True love for Coffin Toast. (The watermelon smoothies is not that good TBH.)